### PR TITLE
Include pandoc and latex deps in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:10 as pspbuilder
 WORKDIR /opt
-RUN apt-get update && apt-get install --assume-yes python3-pip && pip3 install mkdocs mkdocs-material
+RUN apt-get update && apt-get install --assume-yes python3-pip pandoc texlive-base texlive-fonts-recommended texlive-fonts-extra texlive-latex-extra && pip3 install mkdocs mkdocs-material pandoc-latex-admonition
 COPY bin/docker-mkdocs /usr/local/sbin/mkdocs
 COPY bin/docker-psp /usr/local/bin/psp
 COPY . .


### PR DESCRIPTION
These deps are large and can be a pain to install locally. This adds them to the image. Pandoc can then render PDF with a command like:

```
docker run -it -v $(pwd):$(pwd) --rm jupiterone/pspbuilder  pandoc $(pwd)/docs/access.md -f markdown -t latex -o $(pwd)/access.pdf
```