### PR TITLE
Configure dependabot to perform version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  # Enable version updates for npm
+  - package-ecosystem: "npm"
+    # Look for `package.json` and `lock` files in the `root` directory
+    directory: "/"
+    # Check the npm registry for updates every day (weekdays)
+    schedule:
+      interval: "daily"
+
+  # Enable version updates for Docker
+  - package-ecosystem: "docker"
+    # Look for a `Dockerfile` in the `root` directory
+    directory: "/"
+    # Check for updates once a week
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This will cause dependabot to open PRs on a daily cadence when
dependencies are updated in NPM. We want this especially so that we
don't miss picking up published changes to
@jupiterone/security-policy-templates.

Additionally, check for Dockerfile base image updates once a week.
These may contain important security updates, so let's stay on top of
that, too.