### PR TITLE
Split out extras from base Docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,11 +97,49 @@ jobs:
           echo "Dockerfile changed, and/or new NPM module published. Need to update Docker image."
           echo '::set-env name=need_docker_build::true'
 
-      - name: Build and push to Docker Hub
+      - name: Login to DockerHub Registry
         if: env.need_docker_build
-        uses: docker/build-push-action@v1
+        run: echo ${{ secrets.DOCKERHUB_TOKEN }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
+
+      - name: Build the latest Docker image
+        if: env.need_docker_build
+        run: docker build . --file Dockerfile --tag jupiterone/pspbuilder:latest
+
+      - name: Push the latest Docker image
+        if: env.need_docker_build
+        run: docker push jupiterone/pspbuilder:latest
+
+  docker-extras:
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    needs: [test, npm]
+
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@v2
+
+      - name: Detect Dockerfile changes
+        uses: dorny/paths-filter@v2
+        id: filter
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-          repository: jupiterone/pspbuilder
-          tags: latest
+          filters: |
+            dockerchanged:
+              - 'Dockerfile-full'
+
+      - name: Should Build?
+        if: steps.filter.outputs.dockerchanged == 'true' || needs.npm.outputs.didpublishnpm == 'true'
+        run: |
+          echo "Dockerfile changed, and/or new NPM module published. Need to update Docker-extras image."
+          echo '::set-env name=need_docker_build::true'
+
+      - name: Login to DockerHub Registry
+        if: env.need_docker_build
+        run: echo ${{ secrets.DOCKERHUB_TOKEN }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
+
+      - name: Build the latest Docker image
+        if: env.need_docker_build
+        run: docker build . --file Dockerfile-extras --tag jupiterone/pspbuilder-extras:latest
+
+      - name: Push the latest Docker image
+        if: env.need_docker_build
+        run: docker push jupiterone/pspbuilder-extras:latest

--- a/Dockerfile-extras
+++ b/Dockerfile-extras
@@ -3,11 +3,20 @@ WORKDIR /opt
 
 # Install pandoc and other linting/helper tools
 RUN apt-get update && apt-get install --assume-yes \
-  python3-pip
+  aspell \
+  jq \
+  pandoc \
+  python3-pip \
+  texlive-base \
+  texlive-fonts-extra \
+  texlive-fonts-recommended \
+  texlive-latex-extra \
+  texlive-xetex
 
 # Install psp CLI and additional linting tool
 RUN npm install -g \
-  @jupiterone/security-policy-builder
+  @jupiterone/security-policy-builder \
+  markdownlint-cli
 
 # Install Mkdocs
 
@@ -21,3 +30,7 @@ COPY --from=squidfunk/mkdocs-material:5.5.12 /usr/local/lib/python3.8/site-packa
 # This makes the 'mkdocs' command work as a 'docker run' argument
 COPY bin/docker-mkdocs /usr/local/bin/mkdocs
 RUN chmod +x /usr/local/bin/mkdocs
+
+# clean up unnecessary packages
+RUN apt-get remove --purge --assume-yes $(dpkg -l | grep '^ii.*texlive.*doc' | cut -d' ' -f3)
+RUN apt autoremove --purge --assume-yes gcc cpp gcc g++ gnome-icon-theme gtk-update-icon-cache make x11-utils xbitmaps xterm

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ The supported `jupiterone/pspbuilder` docker image has the necessary pandoc
 dependencies installed. You may issue commands like:
 
 ```bash
-docker run -it -v "$PWD":/mnt --rm jupiterone/pspbuilder pandoc /mnt/docs/filename.md -f markdown -t latex --pdf-engine=xelatex --variable monofont="Monaco" -o /mnt/pdf/filename.pdf
+docker run -it -v "$PWD":/mnt --rm jupiterone/pspbuilder-extras pandoc /mnt/docs/filename.md -f markdown -t latex --pdf-engine=xelatex --variable monofont="Monaco" -o /mnt/pdf/filename.pdf
 ```
 
 to convert a single markdown file into a PDF.
@@ -397,7 +397,7 @@ pandoc *.md -f markdown -t latex --latex-engine=xelatex --variable monofont="inc
 Then, issue:
 
 ```bash
-docker run -it -v "$PWD":/mnt --rm jupiterone/pspbuilder /mnt/pdf.sh
+docker run -it -v "$PWD":/mnt --rm jupiterone/pspbuilder-extras /mnt/pdf.sh
 ```
 
 This should stitch together all of your markdown files (in alphabetical order


### PR DESCRIPTION
Publish a smaller base image for psp & mkdocs commands, to keep CI/CD
flows fast, and a larger, "kitchen sink" build for pandoc and other
advanced usage.