### PR TITLE
Upsert policies, procedures and verify the order

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,12 +138,6 @@ or
 docker run -it -v "$PWD":/mnt --rm jupiterone/pspbuilder psp publish -c /mnt/config.json -t /mnt/templates -a $J1_ACCOUNT_ID -k $J1_API_TOKEN
 ```
 
-By default, the `psp publish` command will submit your data to JupiterOne as a
-background job and immediately return. You can optionally add the `--wait`
-option if you would like to wait for the background publishing work to complete.
-When the `--wait` is used, the command polls JupiterOne until the task is
-complete, and a full report of the publish job is printed to the console.
-
 Your JupiterOne token must have `Policies:Admin` privilege, or be issued by an
 account Administrator, in order to publish the contents.
 

--- a/src/commands/psp-publish.ts
+++ b/src/commands/psp-publish.ts
@@ -1,4 +1,3 @@
-import ProgressBar from 'progress';
 import { prompt } from 'inquirer';
 import commander from 'commander';
 import * as error from '~/src/error';
@@ -8,41 +7,23 @@ import publishToConfluence, {
 import path from 'path';
 import fs, { promises as fsPromises } from 'fs';
 import pAll, { PromiseFactory } from 'p-all';
-import pThrottle from 'p-throttle';
 import {
-  EntityForSync,
   PolicyBuilderConfig,
-  SecurityEntityClass,
-  SecurityEntityType,
   SectionName,
   TemplateData,
   PolicyBuilderElement,
-  RelationshipForSync,
 } from '~/src/types';
 import chalk from 'chalk';
-import pickAdopted from '~/src/util/pickAdopted';
 import packageJson from '~/package.json';
 import {
   createJupiterOneClient,
   J1Options,
   JupiterOneClient,
   JupiterOneEnvironment,
-  SyncJob,
-  SyncJobStatus,
 } from '~/src/j1';
-import { PSP_SYNC_SCOPE } from '~/src/constants';
-import { Spinner } from 'cli-spinner';
 
 const EUSAGEERROR = 126;
 const MAX_CONCURRENCY = 2;
-const THROTTLE_INTERVAL = 1000;
-const THROTTLE_LIMIT = 10;
-
-async function sleep(ms: number) {
-  return new Promise((resolve) => {
-    return setTimeout(resolve, ms);
-  });
-}
 
 type ProgramInput = {
   account?: string;
@@ -57,26 +38,6 @@ type ProgramInput = {
   docs?: string;
   wait?: boolean;
 };
-
-function printSyncJobReport(
-  syncJob: SyncJob,
-  propertyNames: (keyof SyncJob)[]
-) {
-  console.log('\nPUBLISH REPORT:\n');
-  for (const propertyName of propertyNames) {
-    if (propertyName.startsWith('num')) {
-      const prettyName = propertyName
-        .replace(/([a-z])([A-Z])/g, (match: string, p1: string, p2: string) => {
-          return p1 + ' ' + p2;
-        })
-        .substring(3);
-      console.log(
-        `  ${chalk.bold(prettyName)} = ${(syncJob as any)[propertyName]}`
-      );
-    }
-  }
-  console.log('');
-}
 
 export async function run() {
   const program = commander
@@ -140,107 +101,34 @@ export async function run() {
   const templateData = await readTemplateData(program, config);
   const j1Client = initializeJ1Client(program);
   await storeConfigWithAccount(program, j1Client, config);
-  await migrateOldSecurityEntitiesToSyncScope(j1Client);
-  await migrateOldSecurityRelationshipsToSyncScope(j1Client);
-
-  const { job: syncJob } = await j1Client.startSyncJob({
-    source: 'api',
-    scope: PSP_SYNC_SCOPE,
-  });
-  const syncJobId = syncJob.id;
-
-  const sectionNames: SectionName[] = ['policies', 'procedures', 'references'];
-
-  const accountId = program.account!;
-
-  for (const sectionName of sectionNames) {
-    await uploadEntitiesForSync({
+  const policyPromises = config.policies.map((p: PolicyBuilderElement) =>
+    upsertPolicy({
+      program,
       j1Client,
+      policy: p,
+      templates: templateData,
       config,
-      templateData,
-      sectionName,
-      syncJobId,
-      accountId,
+    })
+  );
+  try {
+    await Promise.all(policyPromises);
+    console.log('Verifying the order of all policies and procedures...');
+    await j1Client.reorderItems({
+      mapping: {
+        policies: config.policies.map((p: PolicyBuilderElement) => ({
+          id: p.id,
+          procedures: p.procedures || [],
+        })),
+      },
     });
-  }
-
-  await uploadRelationshipsForSync({ j1Client, config, accountId, syncJobId });
-
-  console.log('All data uploaded.');
-
-  const finalizeResult = await j1Client.finalizeSyncJob({ syncJobId });
-
-  if (program.wait === false) {
-    printSyncJobReport(finalizeResult.job, [
-      'numEntitiesUploaded',
-      'numRelationshipsUploaded',
-    ]);
-
-    console.log(
-      chalk.cyan(
-        'Work will be completed in the background. Use "--wait" option to wait for completion.'
-      )
-    );
-
-    console.log(chalk.bold.green('\n\nPublish job submitted.'));
-    return;
-  }
-
-  console.log('Waiting for synchronization to finish...\n');
-
-  const spinner = new Spinner({
-    text: 'Waiting... %s',
-    stream: process.stdout,
-    onTick: function (msg) {
-      this.clearLine(this.stream);
-      this.stream.write(chalk.cyan(msg));
-    },
-  });
-
-  spinner.start();
-
-  let done = false;
-  let lastSyncJobStatus;
-
-  do {
-    lastSyncJobStatus = await j1Client.fetchSyncJobStatus({ syncJobId });
-
-    spinner.setSpinnerTitle(
-      `Job status: ${chalk.bold(lastSyncJobStatus.job.status)}`
-    );
-    done = lastSyncJobStatus.job.done;
-    if (!done) {
-      await sleep(1000);
-    }
-  } while (!done);
-
-  spinner.stop(true);
-
-  printSyncJobReport(lastSyncJobStatus.job, [
-    'numEntitiesUploaded',
-    'numEntitiesCreated',
-    'numEntitiesUpdated',
-    'numEntitiesDeleted',
-    'numEntityCreateErrors',
-    'numEntityUpdateErrors',
-    'numEntityDeleteErrors',
-    'numRelationshipsUploaded',
-    'numRelationshipsCreated',
-    'numRelationshipsUpdated',
-    'numRelationshipsDeleted',
-    'numRelationshipCreateErrors',
-    'numRelationshipUpdateErrors',
-    'numRelationshipDeleteErrors',
-  ]);
-
-  if (lastSyncJobStatus.job.status === SyncJobStatus.FINISHED) {
-    console.log(chalk.bold.green('Publish complete!'));
-  } else {
-    console.log(
-      chalk.bold.red('Publish failed!') +
-        chalk.red(` Status: ${lastSyncJobStatus.job.status}`)
+  } catch (err) {
+    error.fatal(
+      `Error publishing policies and procedures. Error: ${
+        err.stack || err.toString()
+      }`
     );
   }
+  console.log('All items were successfully published');
 }
 
 // ensure user supplied necessary params
@@ -330,149 +218,6 @@ function initializeJ1Client(program: ProgramInput) {
   return j1Client;
 }
 
-async function collectGraphObjectIdsForQueryHelper(
-  j1Client: JupiterOneClient,
-  basequery: string
-) {
-  const idSet = new Set<string>();
-
-  let hasMore: boolean;
-  let skip = 0;
-  const limit = 250;
-  do {
-    const query = `${basequery} ${skip ? `SKIP ${skip}` : ''} LIMIT ${limit}`;
-    const items = await j1Client.queryForEntityTableList(query);
-    for (const item of items) {
-      const id = item['a._id'] as string;
-      idSet.add(id);
-    }
-    hasMore = items.length !== 0;
-    skip += limit;
-  } while (hasMore);
-  return [...idSet];
-}
-
-async function migrateOldSecurityEntitiesToSyncScope(
-  j1Client: JupiterOneClient
-) {
-  const entityTypes: SecurityEntityType[] = [
-    'security_policy',
-    'security_procedure',
-    'security_document',
-  ];
-
-  console.log('Checking for security entities that need to be migrated...');
-  const _idList = await collectGraphObjectIdsForQueryHelper(
-    j1Client,
-    `
-    FIND (${entityTypes.join('|')})
-    WITH _scope != '${PSP_SYNC_SCOPE}' AND _source = 'api' as a
-    RETURN a._id
-    `
-  );
-
-  if (!_idList.length) {
-    console.log('No entities need to be migrated.');
-  } else {
-    console.log(
-      `Found security entities that need to be migrated (count=${_idList.length}). Updating...`
-    );
-    const bar = new ProgressBar(':bar', {
-      total: _idList.length + 1,
-      clear: true,
-      width: 50,
-    });
-    bar.tick();
-
-    const updateEntityThrottled = pThrottle(
-      async (_id: string) => {
-        try {
-          await j1Client.updateEntity({
-            timestamp: Date.now(),
-            entity: {
-              _id,
-              _scope: PSP_SYNC_SCOPE,
-            },
-          });
-        } catch (err) {
-          console.log(
-            `Error updating entity (_id=${_id}). Error: ${err.toString()}`
-          );
-        }
-        bar.tick();
-      },
-      THROTTLE_LIMIT,
-      THROTTLE_INTERVAL
-    );
-
-    const promises = _idList.map(updateEntityThrottled);
-    await Promise.all(promises);
-    console.log('\nFinished migrating old entities.');
-  }
-}
-
-async function migrateOldSecurityRelationshipsToSyncScope(
-  j1Client: JupiterOneClient
-) {
-  console.log('Checking for security relationship that need to be migrated...');
-
-  const implementerTypes: SecurityEntityType[] = [
-    'security_procedure',
-    'security_document',
-  ];
-
-  const policyType: SecurityEntityType = 'security_policy';
-
-  const idList = await collectGraphObjectIdsForQueryHelper(
-    j1Client,
-    `
-    FIND (${implementerTypes.join('|')}) THAT IMPLEMENTS as a ${policyType}
-    WHERE a._scope != '${PSP_SYNC_SCOPE}' AND a._source = 'api'
-    RETURN a._id, a._fromEntityId, a._toEntityId
-    `
-  );
-
-  if (!idList.length) {
-    console.log('No relationships need to be migrated.');
-  } else {
-    console.log(
-      `Found security relationships that need to be migrated (count=${idList.length}). Updating...`
-    );
-    const bar = new ProgressBar(':bar', {
-      total: idList.length + 1,
-      clear: true,
-      width: 50,
-    });
-    bar.tick();
-
-    const updateRelationshipThrottled = pThrottle(
-      async (_id: string) => {
-        try {
-          await j1Client.updateRelationship({
-            timestamp: Date.now(),
-            relationship: {
-              _id,
-              _scope: PSP_SYNC_SCOPE,
-            },
-          });
-        } catch (err) {
-          console.log(
-            `Error updating relationship (_id=${_id}). Error: ${err.toString()}`
-          );
-        }
-
-        bar.tick();
-      },
-      THROTTLE_LIMIT,
-      THROTTLE_INTERVAL
-    );
-
-    const promises = idList.map(updateRelationshipThrottled);
-    await Promise.all(promises);
-    console.log('\nFinished migrating old relationships.');
-  }
-}
-
 async function readTemplateData(
   program: ProgramInput,
   config: PolicyBuilderConfig
@@ -507,6 +252,66 @@ async function readTemplateData(
   return data;
 }
 
+async function upsertPolicy({
+  j1Client,
+  policy,
+  templates,
+  config,
+}: {
+  program: ProgramInput;
+  j1Client: JupiterOneClient;
+  policy: PolicyBuilderElement;
+  templates: TemplateData;
+  config: any;
+}) {
+  const template = templates.policies[policy.id];
+  const { uuid } = await j1Client.upsertPolicy({
+    data: {
+      id: policy.id,
+      file: policy.file,
+      title: policy.name as string,
+      template,
+    },
+  });
+  console.log(`Upserted policy: ${policy.id}`);
+  const isRef = policy.id === 'ref';
+  const upsertProcedurePromises = (policy.procedures as string[])?.map(
+    async (procedureId) => {
+      const procedure = ((isRef
+        ? config.references
+        : config.procedures) as PolicyBuilderElement[]).find(
+        (procedure) => procedure.id === procedureId
+      );
+      if (!procedure) {
+        throw error.fatal(`Unable to find procedure with id: ${procedureId}`);
+      }
+      const template = (isRef ? templates.references : templates.procedures)[
+        procedure.id
+      ];
+
+      await j1Client.upsertProcedure({
+        data: {
+          policyId: uuid,
+          id: procedure.id,
+          isRef,
+          template,
+          file: procedure.file,
+          name: procedure.name as string,
+          provider: procedure.provider,
+          applicable: procedure.applicable,
+          adopted: procedure.adopted,
+          summary: (procedure.summary as string) || '',
+        },
+      });
+      console.log(
+        `Upserted ${isRef ? 'reference' : 'procedure'}: ${procedureId}`
+      );
+    }
+  );
+
+  await Promise.all(upsertProcedurePromises);
+}
+
 async function storeConfigWithAccount(
   program: ProgramInput,
   j1Client: JupiterOneClient,
@@ -529,338 +334,6 @@ async function storeConfigWithAccount(
   }
 }
 
-function buildEntityKey(options: {
-  accountId: string;
-  securityElementId: string;
-  entityType: SecurityEntityType;
-}) {
-  const { accountId, securityElementId, entityType } = options;
-  return `j1:${accountId}:${entityType.replace(
-    /_/g,
-    '-'
-  )}:${securityElementId}`;
-}
-
-async function uploadEntitiesForSync(options: {
-  j1Client: JupiterOneClient;
-  config: PolicyBuilderConfig;
-  templateData: TemplateData;
-  sectionName: SectionName;
-  syncJobId: string;
-  accountId: string;
-}) {
-  const {
-    j1Client,
-    config,
-    templateData,
-    sectionName,
-    syncJobId,
-    accountId,
-  } = options;
-  const j1qlLookup: Record<
-    SectionName,
-    {
-      type: SecurityEntityType;
-      class: SecurityEntityClass[];
-    }
-  > = {
-    policies: { type: 'security_policy', class: ['Document', 'Policy'] },
-    procedures: {
-      type: 'security_procedure',
-      class: ['Document', 'Procedure'],
-    },
-    references: { type: 'security_document', class: ['Document'] },
-  };
-
-  if (!j1qlLookup[sectionName]) {
-    throw new Error(`Unknown config section: ${sectionName}`);
-  }
-
-  const sectionConfig = config[sectionName];
-  const adoptedItems = pickAdopted(sectionConfig);
-  const entityType = j1qlLookup[sectionName].type;
-  const entitiesForSync: EntityForSync[] = [];
-
-  if (adoptedItems.length) {
-    console.log(
-      `Uploading ${adoptedItems.length} configured and adopted ${entityType} entities...`
-    );
-    for (const item of adoptedItems) {
-      const entityKey = buildEntityKey({
-        accountId,
-        entityType,
-        securityElementId: item.id,
-      });
-
-      const templateId = item.id;
-
-      const entityForSync: EntityForSync = {
-        _key: entityKey,
-        _type: entityType,
-        _class: j1qlLookup[sectionName].class,
-        'tag.AccountName': accountId,
-        id: item.id,
-        name: item.id,
-        title: item.name,
-        displayName: item.name,
-        adopted: item.adopted,
-        provider: item.provider,
-        summary: item.summary,
-        type: item.type,
-        webLink: item.webLink || null,
-      };
-
-      const rawDataBody = templateData[sectionName][templateId];
-      if (rawDataBody) {
-        const rawDataEntryName = `policy_template_${sectionName}_${templateId}`;
-        entityForSync._rawData = {
-          [rawDataEntryName]: {
-            body: rawDataBody,
-            contentType: 'application/json',
-          },
-        };
-      }
-
-      entitiesForSync.push(entityForSync);
-    }
-
-    await j1Client.uploadGraphObjectsForSyncJob({
-      entities: entitiesForSync,
-      syncJobId,
-    });
-
-    console.log(
-      `Uploaded ${entitiesForSync.length} ${
-        entitiesForSync.length === 1 ? 'entity' : 'entities'
-      }`
-    );
-  } else {
-    console.log('No adopted items. Nothing to publish.');
-  }
-}
-
-async function uploadRelationshipsForSync(options: {
-  j1Client: JupiterOneClient;
-  config: PolicyBuilderConfig;
-  accountId: string;
-  syncJobId: string;
-}) {
-  const { j1Client, config, accountId, syncJobId } = options;
-  const PROCEDURE_BY_ID_MAP: Record<
-    string,
-    PolicyBuilderElement | undefined
-  > = {};
-  const REFERENCE_BY_ID_MAP: Record<
-    string,
-    PolicyBuilderElement | undefined
-  > = {};
-
-  const adoptedPolicies = config.policies?.filter((policy) => {
-    return policy.adopted !== false;
-  });
-
-  if (!adoptedPolicies || !adoptedPolicies.length) {
-    console.log('No policies are adopted');
-    return;
-  }
-
-  if (config.procedures) {
-    for (const procedure of config.procedures) {
-      if (procedure.adopted) {
-        PROCEDURE_BY_ID_MAP[procedure.id] = procedure;
-      }
-    }
-  }
-
-  if (config.references) {
-    for (const reference of config.references) {
-      if (reference.adopted) {
-        REFERENCE_BY_ID_MAP[reference.id] = reference;
-      }
-    }
-  }
-
-  const buildRelationship = (options: {
-    policyId: string;
-    policyEntityKey: string;
-    implementerId: string;
-  }) => {
-    const { policyId, policyEntityKey, implementerId } = options;
-    let implementer: PolicyBuilderElement | undefined;
-    let implementerType: SecurityEntityType;
-    if ((implementer = PROCEDURE_BY_ID_MAP[implementerId])) {
-      implementerType = 'security_procedure';
-    } else if ((implementer = REFERENCE_BY_ID_MAP[implementerId])) {
-      implementerType = 'security_document';
-    } else {
-      return undefined;
-    }
-
-    const implementerKey = buildEntityKey({
-      accountId,
-      entityType: implementerType,
-      securityElementId: implementer.id,
-    });
-
-    const relationshipKey = `j1:${accountId}:procedure-implements-policy:${implementerId}:${policyId}`;
-
-    const relationshipForSync: RelationshipForSync = {
-      _class: 'IMPLEMENTS',
-      _key: relationshipKey,
-      _type: 'procedure|implements|policy',
-      _fromEntityKey: implementerKey,
-      _toEntityKey: policyEntityKey,
-    };
-
-    return relationshipForSync;
-  };
-
-  const relationshipsForSync: RelationshipForSync[] = [];
-
-  for (const policy of adoptedPolicies) {
-    if (policy.procedures) {
-      const policyEntityKey = buildEntityKey({
-        accountId,
-        entityType: 'security_policy',
-        securityElementId: policy.id,
-      });
-      for (const implementerId of policy.procedures) {
-        const relationshipForSync = buildRelationship({
-          policyId: policy.id,
-          policyEntityKey,
-          implementerId: implementerId,
-        });
-        if (relationshipForSync) {
-          relationshipsForSync.push(relationshipForSync);
-        }
-      }
-    }
-  }
-
-  await j1Client.uploadGraphObjectsForSyncJob({
-    relationships: relationshipsForSync,
-    syncJobId,
-  });
-
-  console.log(
-    `Uploaded ${relationshipsForSync.length} ${
-      relationshipsForSync.length === 1 ? 'relationship' : 'relationships'
-    }`
-  );
-
-  // const implementingSectionNames: SectionName[] = [
-  //   "procedures",
-  //   'references'
-  // ];
-  // const policyEntityType: SecurityEntityType = 'security_policy';
-  // for (const sectionName of implementingSectionNames) {
-  //   const targetEntityKey = `j1:${accountId}:${policyEntityType.replace(
-  //     /_/g,
-  //     '-'
-  //   )}:${item.id}`;
-  // }
-  // if (!shouldUpdateRelationships) {
-  //   return;
-  // }
-  // const rels = (
-  //   await j1Client.queryForGraphObjectTable(
-  //     'find (security_procedure|security_document) that IMPLEMENTS as edge security_policy return edge'
-  //   )
-  // ).map((v) => v.edge);
-  // console.log(`Found ${rels.length} existing IMPLEMENTS relationships...`);
-  // process.stdout.write('Analyzing entity relationships...');
-  // const pspEntities = await j1Client.queryForEntityList(
-  //   'find (security_policy|security_procedure|security_document)'
-  // );
-  // const allPolicyImplementorEntities: Entity[] = [];
-  // const allPolicyEntities: Entity[] = [];
-  // pspEntities.map((entity) => {
-  //   if (entity._type.includes('security_policy')) {
-  //     allPolicyEntities.push(entity);
-  //   } else {
-  //     allPolicyImplementorEntities.push(entity);
-  //   }
-  // });
-  // console.log('OK!');
-  // console.log(
-  //   `Publishing ${allPolicyImplementorEntities.length} relationships... `
-  // );
-  // const bar = new ProgressBar(':bar', {
-  //   total: allPolicyImplementorEntities.length + 1,
-  //   clear: true,
-  //   width: 50,
-  // });
-  // bar.tick();
-  // const throttled = pThrottle(
-  //   async (policy: Entity, implementor: Entity) => {
-  //     const relKey = `j1:${accountId}:procedure-implements-policy:${implementor.id}:${policy.id}`;
-  //     const relType = 'procedure|implements|policy';
-  //     const relClass = 'IMPLEMENTS';
-  //     await j1Client.createRelationship({
-  //       timestamp: Date.now(),
-  //       relationship: {
-  //         _key: relKey,
-  //         _type: relType,
-  //         _class: relClass,
-  //         _fromEntityId: implementor._id,
-  //         _toEntityId: policy._id,
-  //         displayName: relClass,
-  //       },
-  //     });
-  //     bar.tick();
-  //   },
-  //   THROTTLE_LIMIT,
-  //   THROTTLE_INTERVAL
-  // );
-  // for (const policy of allPolicyEntities) {
-  //   // find config for current policy, which contains an array of procedures/references that implement it...
-  //   const policyConfig = config.policies?.find((p) => p.id === policy.id);
-  //   if (!policyConfig) {
-  //     console.warn(
-  //       `Unable to find a matching policy configuration in '${program.config}' for existing graph entity '${policy.id}'. Ignored.`
-  //     );
-  //     continue;
-  //   }
-  //   // get array of entities that implement the current policy entity...
-  //   const implementors = allPolicyImplementorEntities.filter(
-  //     (i) => policyConfig.procedures?.includes(i.id as string) === true
-  //   );
-  //   for (const implementor of implementors) {
-  //     await throttled(policy, implementor);
-  //   }
-  // }
-}
-
 async function readFilePromise(filePath: string) {
   return fsPromises.readFile(filePath, { encoding: 'utf8' });
 }
-
-// async function getFileUpdatedTimePromise(filePath: string) {
-//   const stats = await fsPromises.stat(filePath);
-//   return stats.mtime;
-// }
-
-// function templateDataUpsertBuilder(
-//   j1Client: JupiterOneClient,
-//   templateData: TemplateData,
-//   configSection: SectionName,
-//   templateId: string
-// ) {
-//   return async (entityId: string) => {
-//     const name = `policy_template_${configSection}_${templateId}`;
-//     try {
-//       await j1Client.uploadEntityRawData({
-//         entityId,
-//         entryName: name,
-//         contentType: 'text/html',
-//         body: templateData.data[configSection][templateId],
-//       });
-//     } catch (err) {
-//       error.warn(
-//         `Error storing PSP template data (${configSection}/${templateId}). Error: ${
-//           err.stack || err.toString()
-//         }`
-//       );
-//     }
-//   };
-// }

--- a/src/j1/index.ts
+++ b/src/j1/index.ts
@@ -62,6 +62,7 @@ async function makeGraphQLRequest<I, O>(options: {
   j1Client: JupiterOneClient;
   query: JupiterOneQuery<I, O>;
   input: I;
+  resultKey?: string;
 }) {
   const { apiUrl } = options;
   const headers = buildRequestHeaders(options.j1Client, {
@@ -89,7 +90,7 @@ async function makeGraphQLRequest<I, O>(options: {
     throw new GraphQLResponseError(errors);
   }
 
-  return (bodyObj as GraphQLApiResponseBodyWithResult<O>).data.result;
+  return bodyObj.data[options.resultKey || 'result'] as O;
 }
 
 export type DeferredJ1QLQueryState = {
@@ -248,7 +249,7 @@ class FetchError extends Error {
     super(
       `JupiterOne API error. Response not OK (requestName=${
         options.nameForLogging || '(none)'
-      }, status=${status}, url=${options.url}, method=${
+      }, status=${options.response.status}, url=${options.url}, method=${
         options.method
       }). Response: ${options.responseBody}`
     );
@@ -489,6 +490,45 @@ class JupiterOneClient {
       j1Client: this,
       input,
       query: j1GraphQL.MUTATION_UPDATE_CONFIG,
+    });
+  }
+
+  async upsertPolicy(input: j1GraphQL.UpsertPolicyInput) {
+    return makeGraphQLRequest<
+      j1GraphQL.UpsertPolicyInput,
+      j1GraphQL.UpsertPolicyOutput
+    >({
+      apiUrl: this.queryGraphQLApiUrl,
+      j1Client: this,
+      input,
+      query: j1GraphQL.MUTATION_UPSERT_POLICY,
+      resultKey: 'upsertPolicyById',
+    });
+  }
+
+  async upsertProcedure(input: j1GraphQL.UpsertProcedureInput) {
+    return makeGraphQLRequest<
+      j1GraphQL.UpsertProcedureInput,
+      j1GraphQL.UpsertProcedureOutput
+    >({
+      apiUrl: this.queryGraphQLApiUrl,
+      j1Client: this,
+      input,
+      query: j1GraphQL.MUTATION_UPSERT_PROCEDURE,
+      resultKey: 'upsertProcedureById',
+    });
+  }
+
+  async reorderItems(input: j1GraphQL.ReorderAllItemsByMappingInput) {
+    return makeGraphQLRequest<
+      j1GraphQL.ReorderAllItemsByMappingInput,
+      j1GraphQL.ReorderAllItemsByMappingOutput
+    >({
+      apiUrl: this.queryGraphQLApiUrl,
+      j1Client: this,
+      input,
+      query: j1GraphQL.MUTATION_REORDER_ITEMS,
+      resultKey: 'reorderAllItemsByMapping',
     });
   }
 }

--- a/src/j1/index.ts
+++ b/src/j1/index.ts
@@ -479,6 +479,18 @@ class JupiterOneClient {
       query: j1GraphQL.MUTATION_UPDATE_RELATIONSHIP,
     });
   }
+
+  async updateConfig(input: j1GraphQL.UpdateConfigInput) {
+    return makeGraphQLRequest<
+      j1GraphQL.UpdateConfigInput,
+      j1GraphQL.UpdateConfigOutput
+    >({
+      apiUrl: this.queryGraphQLApiUrl,
+      j1Client: this,
+      input,
+      query: j1GraphQL.MUTATION_UPDATE_CONFIG,
+    });
+  }
 }
 
 export function createJupiterOneClient(options: J1Options) {

--- a/src/j1/j1GraphQL.ts
+++ b/src/j1/j1GraphQL.ts
@@ -98,14 +98,98 @@ export type UpdateConfigOutput = {
 };
 
 export const MUTATION_UPDATE_CONFIG: JupiterOneGraphQLQuery<
-  UpdateRelationshipInput,
-  UpdateRelationshipOutput
+  UpdateConfigInput,
+  UpdateConfigOutput
 > = {
   nameForLogging: 'Update Config',
   ast: gql`
     mutation updateCompanyValues($values: JSON!) {
       updateCompanyValues(values: $values) {
         values
+      }
+    }
+  `,
+};
+
+export type UpsertPolicyInput = {
+  data: {
+    id: string;
+    file: string;
+    title: string;
+    template: string;
+  };
+};
+
+export type UpsertPolicyOutput = {
+  uuid: string;
+};
+
+export const MUTATION_UPSERT_POLICY: JupiterOneGraphQLQuery<
+  UpsertPolicyInput,
+  UpsertPolicyOutput
+> = {
+  nameForLogging: 'Upsert Policy',
+  ast: gql`
+    mutation upsertPolicyById($data: CreatePolicyInput!) {
+      upsertPolicyById(data: $data) {
+        uuid
+      }
+    }
+  `,
+};
+
+export type UpsertProcedureInput = {
+  data: {
+    id: string;
+    file: string;
+    name: string;
+    policyId: string;
+    template: string;
+    provider?: string;
+    isRef?: boolean;
+    applicable?: boolean;
+    adopted?: boolean;
+    summary: string;
+  };
+};
+
+export type UpsertProcedureOutput = {
+  uuid: string;
+};
+
+export const MUTATION_UPSERT_PROCEDURE: JupiterOneGraphQLQuery<
+  UpsertPolicyInput,
+  UpsertPolicyOutput
+> = {
+  nameForLogging: 'Upsert Policy',
+  ast: gql`
+    mutation upsertProcedureById($data: CreateProcedureInput!) {
+      upsertProcedureById(data: $data) {
+        uuid
+      }
+    }
+  `,
+};
+
+export type ReorderAllItemsByMappingInput = {
+  mapping: { policies: { id: string; procedures: string[] }[] };
+};
+
+export type ReorderAllItemsByMappingOutput = {
+  uuid: string;
+};
+
+export const MUTATION_REORDER_ITEMS: JupiterOneGraphQLQuery<
+  ReorderAllItemsByMappingInput,
+  ReorderAllItemsByMappingOutput
+> = {
+  nameForLogging: 'Upsert Policy',
+  ast: gql`
+    mutation reorderAllItemsByMapping($mapping: PolicyMappingInput!) {
+      reorderAllItemsByMapping(mapping: $mapping) {
+        policies {
+          id
+        }
       }
     }
   `,

--- a/src/j1/j1GraphQL.ts
+++ b/src/j1/j1GraphQL.ts
@@ -1,6 +1,7 @@
 import gql from 'graphql-tag';
 import { EntityPropertyValue, Entity, Relationship } from '~/src/j1/types';
 import { JupiterOneQuery as JupiterOneGraphQLQuery } from '~/src/j1';
+import { PolicyBuilderConfig } from '../types';
 
 export type J1QLVariables = Record<string, EntityPropertyValue>;
 
@@ -81,6 +82,30 @@ export const MUTATION_UPDATE_RELATIONSHIP: JupiterOneGraphQLQuery<
         relationship: $relationship
       ) {
         relationship
+      }
+    }
+  `,
+};
+
+export type UpdateConfigInput = {
+  values: PolicyBuilderConfig['organization'];
+};
+
+export type UpdateConfigOutput = {
+  values: {
+    config: PolicyBuilderConfig['organization'];
+  };
+};
+
+export const MUTATION_UPDATE_CONFIG: JupiterOneGraphQLQuery<
+  UpdateRelationshipInput,
+  UpdateRelationshipOutput
+> = {
+  nameForLogging: 'Update Config',
+  ast: gql`
+    mutation updateCompanyValues($values: JSON!) {
+      updateCompanyValues(values: $values) {
+        values
       }
     }
   `,


### PR DESCRIPTION
When running psp publish, if a policy/procedure with the given id already exists then it will be updated. If not, then a new one will be created. When the upserts are complete, a reordering call is made in order to make sure all items are in the order specified in the config.json. Any items that are in the UI but are not specified in the config.json will be ordered last.